### PR TITLE
(maint) Add PE Client Tools to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project contains the automatic updating packages for the public community c
 ## Package List
 
 * [pdk](https://chocolatey.org/packages/pdk)
+* [pe-client-tools](https://chocolatey.org/packages/pe-client-tools)
 * [puppet-agent](https://chocolatey.org/packages/puppet-agent)
 
 ## Development


### PR DESCRIPTION
This commit adds PE Client Tools to readme file.