### PR TITLE
(maint) Protect pushing packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ branches:
 environment:
   # Set au version to use or omit to use the latest. Specify branch name to use development version from Github
   au_version:
-  au_push: true
+  au_push: false
   # Force test: use 1 to test all, or N to split testing into N groups
   au_test_groups: 1
 
@@ -66,14 +66,17 @@ build_script:
 - ps: |
     $ErrorActionPreference = 'Continue'
 
+    if ($Env:APPVEYOR_SCHEDULED_BUILD -eq 'true') { Write-Host "Enabling pushing of packages"; $Env:au_push = 'true' }
+
     if ($Env:APPVEYOR_PROJECT_NAME  -like '*test*') { ./test_all.ps1 "random $Env:au_test_groups"; return }
 
     if ( ($Env:APPVEYOR_SCHEDULED_BUILD -ne 'true') -and ($Env:APPVEYOR_FORCED_BUILD -ne 'true') ) {
         switch -regex ($Env:APPVEYOR_REPO_COMMIT_MESSAGE)
         {
-            '\[AU (.+?)\]'   { $forced = $Matches[1] }
+            '\[AU (.+?)\]'   { $forced = $Matches[1]; Write-Host "Enabling pushing of packages"; $Env:au_push = 'true' }
 
             '\[PUSH (.+?)\]' {
+                Write-Host "Enabling pushing of packages"; $Env:au_push = 'true'
                 $packages = $Matches[1] -split ' '
                 Write-Host "PUSHING PACKAGES: $packages"
                 foreach ($package in $packages) {


### PR DESCRIPTION
Previously packages would always be pushed.  This commit modifies the push
environment variable to not attempt pushing packages unless it is a scheduled
build, or it's a non-forced build with a specific commit messages.