### PR TITLE
(maint) Redo push protection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ branches:
 environment:
   # Set au version to use or omit to use the latest. Specify branch name to use development version from Github
   au_version:
-  au_push: false
+  au_push: true
   # Force test: use 1 to test all, or N to split testing into N groups
   au_test_groups: 1
 
@@ -66,17 +66,14 @@ build_script:
 - ps: |
     $ErrorActionPreference = 'Continue'
 
-    if ($Env:APPVEYOR_SCHEDULED_BUILD -eq 'true') { Write-Host "Enabling pushing of packages"; $Env:au_push = 'true' }
-
     if ($Env:APPVEYOR_PROJECT_NAME  -like '*test*') { ./test_all.ps1 "random $Env:au_test_groups"; return }
 
     if ( ($Env:APPVEYOR_SCHEDULED_BUILD -ne 'true') -and ($Env:APPVEYOR_FORCED_BUILD -ne 'true') ) {
         switch -regex ($Env:APPVEYOR_REPO_COMMIT_MESSAGE)
         {
-            '\[AU (.+?)\]'   { $forced = $Matches[1]; Write-Host "Enabling pushing of packages"; $Env:au_push = 'true' }
+            '\[AU (.+?)\]'   { $forced = $Matches[1] }
 
             '\[PUSH (.+?)\]' {
-                Write-Host "Enabling pushing of packages"; $Env:au_push = 'true'
                 $packages = $Matches[1] -split ' '
                 Write-Host "PUSHING PACKAGES: $packages"
                 foreach ($package in $packages) {
@@ -86,6 +83,13 @@ build_script:
                     pushd $package_dir; choco pack; Push-Package; popd
                 }
                 return
+            }
+
+            default {
+                Write-Host "Commit message is not automated format.  Disabling Pushing, Git and Gist"
+                $Env:au_push = 'false'
+                $Env:github_api_key = ''
+                $Env:gist_id = ''
             }
         }
     }


### PR DESCRIPTION
Previously in commit f732f7c pushing was protected however it was incomplete and
stopped manual rebuilds from triggering pushes

This commit changes the push behaviour to be the default, but will disable
choco push and git operations if a usual webhook build (non-forced,
non-scheduled) does not meet the commit message automation requirements.