### PR TITLE
(maint) Embed the MSI in the nuget pkgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ ketarin/soluto.xml
 update_vars.ps1
 update_info.xml
 Update-AUPackages.md
+# Ignore downloaded packages
+*.msi

--- a/automatic/pdk/tools/chocolateyinstall.ps1
+++ b/automatic/pdk/tools/chocolateyinstall.ps1
@@ -1,20 +1,26 @@
 ﻿$packageName = 'pdk'
 $url32       = ''
 $url64       = 'https://downloads.puppetlabs.com/windows/pdk-1.10.0.0-x64.msi'
+$filename32  = ''
+$filename64  = ''
 $checksum32  = ''
 $checksum64  = 'd83c1a0e2be44b9d646f52c2d17504b92a06888c6f824a5b5a2c4783a46b31f4'
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'MSI'
-  url            = $url32
-  url64bit       = $url64
-  checksum       = $checksum32
-  checksum64     = $checksum64
-  checksumType   = 'sha256'
-  checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+if ([string]::IsNullOrEmpty($filename32)) {
+  # If 64bit only, then only use the file parameter
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+} else {
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename32)
+  $packageArgs['file64'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+}
+
+Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/pdk/update.ps1
+++ b/automatic/pdk/update.ps1
@@ -2,13 +2,21 @@ import-module au
 
 # No trailing slash
 # Order is important.  Most recent first
-$downloadURLs = @('https://downloads.puppetlabs.com/windows')
+$downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
+                  'https://downloads.puppetlabs.com/windows/puppet5')
+
+function global:au_BeforeUpdate() {
+  # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.
+  Get-RemoteFiles -Purge
+}
 
 function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
       "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
       "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
+      "(^[$]filename32\s*=\s*)('.*')" = "`$1'$($Latest.filename32)'"
+      "(^[$]filename64\s*=\s*)('.*')" = "`$1'$($Latest.filename64)'"
       "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
       "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
     }
@@ -26,12 +34,12 @@ function global:au_GetLatest {
     # Extract all of the pdk versions
     # e.g. pdk-1.4.1.2-x64.msi
     $re  = "pdk-(\d+\.\d+\.\d+\.\d+)-x(86|64).msi"
-    $versionList = $download_page.links | % {
+    $versionList = $download_page.links | ForEach-Object {
       if ($matches.count -gt 0) { [void]$matches.clear }
       if ($_ -match $re) {
         Write-Output ([System.Version]$matches[1])
       }
-    } | Sort -Descending | % {
+    } | Sort-Object -Descending | ForEach-Object {
       $ver = $_
       $minorVer = $ver.ToString(2)
       if (!$streams.Contains($minorVer)) {
@@ -46,5 +54,5 @@ function global:au_GetLatest {
   @{ Streams = $streams }
 }
 
-# PDK is a 64bit only package
-update -ChecksumFor 64
+# As we download the MSIs, no need for Checksums
+update -ChecksumFor none

--- a/automatic/puppet-agent/tools/chocolateyinstall.ps1
+++ b/automatic/puppet-agent/tools/chocolateyinstall.ps1
@@ -1,21 +1,26 @@
 ﻿$packageName = 'puppet-agent'
 $url32       = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.4.1-x86.msi'
 $url64       = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.4.1-x64.msi'
+$filename32  = ''
+$filename64  = ''
 $checksum32  = '5ecbf0e28fa8d300fc50b9468a48d7cb456b15febc5a1aff8f2a04ac9ee95e6d'
 $checksum64  = '9549a3bd671d8f5d64c82f661b54ae0dd472ab17abe48b828169ca289a09ab39'
 
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'MSI'
-  url            = $url32
-  url64bit       = $url64
-  checksum       = $checksum32
-  checksum64     = $checksum64
-  checksumType   = 'sha256'
-  checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+if ([string]::IsNullOrEmpty($filename32)) {
+  # If 64bit only, then only use the file parameter
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+} else {
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename32)
+  $packageArgs['file64'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+}
+
+Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/puppet-bolt/tools/chocolateyinstall.ps1
+++ b/automatic/puppet-bolt/tools/chocolateyinstall.ps1
@@ -1,20 +1,26 @@
 ﻿$packageName = 'puppet-bolt'
 $url32       = ''
 $url64       = 'https://downloads.puppetlabs.com/windows/puppet-bolt-1.16.0-x64.msi'
+$filename32  = ''
+$filename64  = ''
 $checksum32  = ''
 $checksum64  = 'fe572b52d0eea6334009478f3605a5b704fc96c1cf9dca5e0ab5a8feca475fdc'
+
+$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'MSI'
-  url            = $url32
-  url64bit       = $url64
-  checksum       = $checksum32
-  checksum64     = $checksum64
-  checksumType   = 'sha256'
-  checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+if ([string]::IsNullOrEmpty($filename32)) {
+  # If 64bit only, then only use the file parameter
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+} else {
+  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename32)
+  $packageArgs['file64'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
+}
+
+Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/puppet-bolt/update.ps1
+++ b/automatic/puppet-bolt/update.ps1
@@ -2,13 +2,21 @@ import-module au
 
 # No trailing slash
 # Order is important.  Most recent first
-$downloadURLs = @('https://downloads.puppetlabs.com/windows')
+$downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
+                  'https://downloads.puppetlabs.com/windows/puppet5')
+
+function global:au_BeforeUpdate() {
+  # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.
+  Get-RemoteFiles -Purge
+}
 
 function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
       "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
       "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
+      "(^[$]filename32\s*=\s*)('.*')" = "`$1'$($Latest.filename32)'"
+      "(^[$]filename64\s*=\s*)('.*')" = "`$1'$($Latest.filename64)'"
       "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
       "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
     }
@@ -19,19 +27,19 @@ function global:au_GetLatest {
 
   $streams = [ordered]@{}
 
-  $downloadURLs | % {
+  $downloadURLs | ForEach-Object -Process {
     $downloadURL = $_
     $download_page = Invoke-WebRequest -Uri $downloadURL
 
     # Extract all of the puppet-bolt versions
     # e.g. puppet-bolt-0.20.3-x64.msi
     $re  = "puppet-bolt-(\d+\.\d+\.\d+)-x(86|64).msi"
-    $versionList = $download_page.links | % {
+    $versionList = $download_page.links | ForEach-Object {
       if ($matches.count -gt 0) { [void]$matches.clear }
       if ($_ -match $re) {
         Write-Output ([System.Version]$matches[1])
       }
-    } | Sort -Descending | % {
+    } | Sort-Object -Descending | % {
       $ver = $_
       $minorVer = $ver.ToString(2)
       if (!$streams.Contains($minorVer)) {
@@ -46,5 +54,5 @@ function global:au_GetLatest {
   @{ Streams = $streams }
 }
 
-# Bolt is a 64bit only package
-update -ChecksumFor 64
+# As we download the MSIs, no need for Checksums
+update -ChecksumFor none


### PR DESCRIPTION
Previously the PDK, Bolt and Puppet-Agent packages relied on downloading the MSI
files from well known URLs, however the URLs will be moving soon which caused
all of the packages to be rebuilt.  To make the packages resistant to URL
changes in the future these packages will now contain the actual MSIs needed to
install, instead of the URL to the MSIs.