### PR TITLE
(maint) PDK Chocolatey package should not vendor the MSI

### DIFF
--- a/automatic/pdk/tools/chocolateyinstall.ps1
+++ b/automatic/pdk/tools/chocolateyinstall.ps1
@@ -1,26 +1,20 @@
 ﻿$packageName = 'pdk'
 $url32       = ''
 $url64       = 'https://downloads.puppetlabs.com/windows/pdk-1.10.0.0-x64.msi'
-$filename32  = ''
-$filename64  = ''
 $checksum32  = ''
 $checksum64  = 'd83c1a0e2be44b9d646f52c2d17504b92a06888c6f824a5b5a2c4783a46b31f4'
-
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'MSI'
+  url            = $url32
+  url64bit       = $url64
+  checksum       = $checksum32
+  checksum64     = $checksum64
+  checksumType   = 'sha256'
+  checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
 }
 
-if ([string]::IsNullOrEmpty($filename32)) {
-  # If 64bit only, then only use the file parameter
-  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
-} else {
-  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename32)
-  $packageArgs['file64'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
-}
-
-Install-ChocolateyInstallPackage @packageArgs
+Install-ChocolateyPackage @packageArgs

--- a/automatic/pdk/update.ps1
+++ b/automatic/pdk/update.ps1
@@ -5,18 +5,11 @@ import-module au
 $downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
                   'https://downloads.puppetlabs.com/windows/puppet5')
 
-function global:au_BeforeUpdate() {
-  # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.
-  Get-RemoteFiles -Purge
-}
-
 function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
       "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
       "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-      "(^[$]filename32\s*=\s*)('.*')" = "`$1'$($Latest.filename32)'"
-      "(^[$]filename64\s*=\s*)('.*')" = "`$1'$($Latest.filename64)'"
       "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
       "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
     }
@@ -54,5 +47,5 @@ function global:au_GetLatest {
   @{ Streams = $streams }
 }
 
-# As we download the MSIs, no need for Checksums
-update -ChecksumFor none
+# PDK is a 64bit only package
+update -ChecksumFor 64


### PR DESCRIPTION
Previously in commit c96fe7f4 the PDK packaging was modified to vendor the MSI,
however the PDK MSI is growing quite large and will soon exceed to the 200MB
limit.  This means it cannot be vendored into the package.  This commit
partially reverts the changes in commit c96fe7f4 and instead uses the new URLs
for the PDK location instead of the old broken URI.