### PR TITLE
(maint) Disable puppet agent publishing

### DIFF
--- a/automatic/puppet-agent/update.ps1
+++ b/automatic/puppet-agent/update.ps1
@@ -2,9 +2,7 @@ import-module au
 
 # No trailing slash
 # Order is important.  Most recent first
-$downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
-                  'https://downloads.puppetlabs.com/windows/puppet5',
-                  'https://release-archives.puppet.com/downloads/windows/')
+$downloadURLs = @()
 
 function global:au_BeforeUpdate() {
   # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.


### PR DESCRIPTION
Currently the puppet agent packages which vendor the MSI are not working
correctly.  This commit temporarily disables any publishing of the puppet
pacakges.  Once the package creation is fixed this commit can be reverted.