### PR TITLE
(maint) PDK Puppet Agent package should not vendor the MSI

### DIFF
--- a/automatic/puppet-agent/tools/chocolateyinstall.ps1
+++ b/automatic/puppet-agent/tools/chocolateyinstall.ps1
@@ -1,26 +1,21 @@
 ﻿$packageName = 'puppet-agent'
 $url32       = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.4.1-x86.msi'
 $url64       = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.4.1-x64.msi'
-$filename32  = ''
-$filename64  = ''
 $checksum32  = '5ecbf0e28fa8d300fc50b9468a48d7cb456b15febc5a1aff8f2a04ac9ee95e6d'
 $checksum64  = '9549a3bd671d8f5d64c82f661b54ae0dd472ab17abe48b828169ca289a09ab39'
 
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $packageName
   fileType       = 'MSI'
+  url            = $url32
+  url64bit       = $url64
+  checksum       = $checksum32
+  checksum64     = $checksum64
+  checksumType   = 'sha256'
+  checksumType64 = 'sha256'
   silentArgs     = "/qn /norestart"
   validExitCodes = @(0, 3010, 1641)
 }
 
-if ([string]::IsNullOrEmpty($filename32)) {
-  # If 64bit only, then only use the file parameter
-  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
-} else {
-  $packageArgs['file'] = (Join-Path -Path $toolsDir -ChildPath $filename32)
-  $packageArgs['file64'] = (Join-Path -Path $toolsDir -ChildPath $filename64)
-}
-
-Install-ChocolateyInstallPackage @packageArgs
+Install-ChocolateyPackage @packageArgs

--- a/automatic/puppet-agent/update.ps1
+++ b/automatic/puppet-agent/update.ps1
@@ -6,18 +6,11 @@ $downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
                   'https://downloads.puppetlabs.com/windows/puppet5',
                   'https://release-archives.puppet.com/downloads/windows/')
 
-function global:au_BeforeUpdate() {
-  # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.
-  Get-RemoteFiles -Purge
-}
-
 function global:au_SearchReplace {
   @{
     'tools\chocolateyInstall.ps1' = @{
         "(^[$]url64\s*=\s*)('.*')"      = "`$1'$($Latest.URL64)'"
         "(^[$]url32\s*=\s*)('.*')"      = "`$1'$($Latest.URL32)'"
-        "(^[$]filename32\s*=\s*)('.*')" = "`$1'$($Latest.filename32)'"
-        "(^[$]filename64\s*=\s*)('.*')" = "`$1'$($Latest.filename64)'"
         "(^[$]checksum32\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
         "(^[$]checksum64\s*=\s*)('.*')" = "`$1'$($Latest.Checksum64)'"
     }
@@ -56,5 +49,4 @@ function global:au_GetLatest {
   @{ Streams = $streams }
 }
 
-# As we download the MSIs, no need for Checksums
-update -ChecksumFor none
+update


### PR DESCRIPTION
Previously in commit c96fe7f4 the Puppet Agent packaging was modified to vendor
the MSI, however the combined 32 and 64 but package size is growing quite large
and may exceed to the 200MB limit.  This means they cannot be vendored into the
package.  This commit partially reverts the changes in commit c96fe7f4 and
instead uses the new URLs for the Puppet Agent location instead of the old
broken URI.