### PR TITLE
Revert "(maint) Disable puppet agent publishing"

### DIFF
--- a/automatic/puppet-agent/update.ps1
+++ b/automatic/puppet-agent/update.ps1
@@ -2,7 +2,9 @@ import-module au
 
 # No trailing slash
 # Order is important.  Most recent first
-$downloadURLs = @()
+$downloadURLs = @('https://downloads.puppetlabs.com/windows/puppet6',
+                  'https://downloads.puppetlabs.com/windows/puppet5',
+                  'https://release-archives.puppet.com/downloads/windows')
 
 function global:au_SearchReplace {
   @{


### PR DESCRIPTION
The Puppet Agent packages are now working correctly.  Puppet Agent publishing can now be re-enabled.

This reverts commit e43fea00060bf40385b2f227157110816f5ae7f5.