### PR TITLE
(GH-2443) Change puppet-bolt ship location

### DIFF
--- a/automatic/puppet-bolt/update.ps1
+++ b/automatic/puppet-bolt/update.ps1
@@ -2,8 +2,8 @@ import-module au
 
 # No trailing slash
 # Order is important.  Most recent first
-$downloadURLs = @('https://downloads.puppet.com/windows/puppet6',
-                  'https://downloads.puppet.com/windows/puppet5')
+$downloadURLs = @('https://downloads.puppet.com/windows/puppet-tools',
+    'https://downloads.puppet.com/windows/puppet5')
 
 function global:au_BeforeUpdate() {
   # Download $Latest.URL32 / $Latest.URL64 in tools directory and remove any older installers.


### PR DESCRIPTION
When looking for `puppet-bolt` packages to ship to chocolatey, the tool
will now search in https://downloads.puppet.com/windows/puppet-tools, where we ship new (and old, back to 1.27.0) versions.