### PR TITLE
Update URLs to pass validation

### DIFF
--- a/automatic/puppet-agent/puppet-agent.nuspec
+++ b/automatic/puppet-agent/puppet-agent.nuspec
@@ -6,13 +6,13 @@
     <title>Puppet Agent (Install)</title>
     <authors>Puppet</authors>
     <owners>Puppet</owners>
-    <projectUrl>https://puppet.com/puppet/puppet-open-source/</projectUrl>
+    <projectUrl>https://puppet.com/docs/puppet/latest</projectUrl>
     <packageSourceUrl>https://github.com/puppetlabs/puppet-chocolatey-packages/tree/master/automatic/puppet-agent</packageSourceUrl>
     <projectSourceUrl>https://github.com/puppetlabs/puppet</projectSourceUrl>
     <docsUrl>https://learn.puppet.com/</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/puppet-users</mailingListUrl>
     <bugTrackerUrl>https://tickets.puppet.com/browse/PUP</bugTrackerUrl>
-    <licenseUrl>https://github.com/puppetlabs/puppet/blob/master/LICENSE</licenseUrl>
+    <licenseUrl>https://github.com/puppetlabs/puppet/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/puppetlabs/puppet-chocolatey-packages/master/icons/puppet.png</iconUrl>
     <description>
@@ -20,7 +20,7 @@ Puppet is a flexible, customizable framework available under the Apache 2.0 lice
 
 Puppet Open Source is the underlying technology for Puppet Enterprise and runs on all major Linux distributions, major Unix platforms like Solaris, HP-UX, and AIX, and Microsoft Windows.
 
-Puppet Agent is an "All-in-One" package that installs Puppet, Ruby, Facter, Hiera, MCollective (mco), PXP and supporting code. It is all you need to start using Puppet. See http://docs.puppetlabs.com/puppet/latest/reference/install_windows.html for more information.
+Puppet Agent is an "All-in-One" package that installs Puppet, Ruby, Facter, Hiera, MCollective (mco), PXP and supporting code. It is all you need to start using Puppet. See https://puppet.com/docs/puppet/latest/puppet_index.html for more information.
 
 
 ### Install Options
@@ -37,7 +37,7 @@ out of date by more than a day or two, please contact the maintainer(s) and
 let them know the package is no longer updating correctly.
     </description>
     <summary>Puppet is IT automation software that helps system administrators manage infrastructure throughout its lifecycle, from provisioning and configuration to patch management and compliance</summary>
-    <releaseNotes>See https://docs.puppet.com/release_notes/</releaseNotes>
+    <releaseNotes>See https://puppet.com/docs/puppet/latest/release_notes_osp.html</releaseNotes>
     <copyright>Puppet, Inc</copyright>
     <tags>puppet configuration management infrastructure automation facter hiera mco mcollective marionette collective</tags>
     <provides>puppet</provides>


### PR DESCRIPTION
Validation is currently failing due to an invalid projectUrl. Also update
URLs in releaseNotes and descriptions to satisify "Guidelines", and license.

[1] https://groups.google.com/a/puppet.com/g/discuss-windows/c/hrP0U1CpKwI/m/G52RMQG_CAAJ