### PR TITLE
(PA-5717) Add resolvable URL for bugTrackerUrl

### DIFF
--- a/automatic/puppet-agent/puppet-agent.nuspec
+++ b/automatic/puppet-agent/puppet-agent.nuspec
@@ -11,7 +11,7 @@
     <projectSourceUrl>https://github.com/puppetlabs/puppet</projectSourceUrl>
     <docsUrl>https://learn.puppet.com/</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/puppet-users</mailingListUrl>
-    <bugTrackerUrl>https://tickets.puppet.com/browse/PUP</bugTrackerUrl>
+    <bugTrackerUrl>https://puppet.atlassian.net/browse/PUP/</bugTrackerUrl>
     <licenseUrl>https://github.com/puppetlabs/puppet/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <iconUrl>https://cdn.rawgit.com/puppetlabs/puppet-chocolatey-packages/master/icons/puppet.png</iconUrl>


### PR DESCRIPTION
The old tickets.puppet.com domain has an expired cert, so move this to the new cloud puppet domain for now.