### PR TITLE
Update pdk CODEOWNER to devx

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,5 +3,5 @@
 * @puppetlabs/windows @glennsarti
 
 # Individual projects
-automatic/pdk/          @puppetlabs/pdk
+automatic/pdk/          @puppetlabs/devx
 automatic/puppet-bolt/  @puppetlabs/bolt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default owners. Note that the Windows team is defunct
 # but a useful collection of people with Windows experience
-* @puppetlabs/windows @glennsarti
+* @puppetlabs/windows
 
 # Individual projects
 automatic/pdk/          @puppetlabs/devx


### PR DESCRIPTION
The pdk is owned by the `puppetlabs/devx` team now so updating in line with current status